### PR TITLE
Allow origin to be configured when doing a cf auth

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	ShouldKeepUser       bool   `json:"keep_user_at_suite_end"`
 	ExistingUser         string `json:"existing_user"`
 	ExistingUserPassword string `json:"existing_user_password"`
+	ExistingUserOrigin   string `json:"existing_user_origin"`
 
 	ExistingClient       string `json:"existing_client"`
 	ExistingClientSecret string `json:"existing_client_secret"`
@@ -256,6 +257,10 @@ func (c *Config) GetExistingUser() string {
 
 func (c *Config) GetExistingUserPassword() string {
 	return c.ExistingUserPassword
+}
+
+func (c *Config) GetExistingUserOrigin() string {
+	return c.ExistingUserOrigin
 }
 
 func (c *Config) GetConfigurableTestPassword() string {

--- a/workflowhelpers/internal/cf_auth.go
+++ b/workflowhelpers/internal/cf_auth.go
@@ -13,8 +13,13 @@ import (
 const VerboseAuth = "RELINT_VERBOSE_AUTH"
 const CFAuthRetries = 2
 
-func CfAuth(cmdStarter internal.Starter, reporter internal.Reporter, user string, password string, timeout time.Duration) error {
+func CfAuth(cmdStarter internal.Starter, reporter internal.Reporter, user string, password string, origin string, timeout time.Duration) error {
 	args := []string{"auth", user, password}
+
+	if origin != "" {
+		args = append(args, "--origin", origin)
+	}
+
 	if os.Getenv(VerboseAuth) == "true" {
 		args = append(args, "-v")
 	}

--- a/workflowhelpers/internal/fakes/fake_user_values.go
+++ b/workflowhelpers/internal/fakes/fake_user_values.go
@@ -3,12 +3,14 @@ package fakes
 type FakeUserValues struct {
 	username string
 	password string
+	origin   string
 }
 
-func NewFakeUserValues(username, password string) *FakeUserValues {
+func NewFakeUserValues(username, password, origin string) *FakeUserValues {
 	return &FakeUserValues{
 		username: username,
 		password: password,
+		origin: origin,
 	}
 }
 
@@ -18,4 +20,8 @@ func (user *FakeUserValues) Username() string {
 
 func (user *FakeUserValues) Password() string {
 	return user.password
+}
+
+func (user *FakeUserValues) Origin() string {
+	return user.origin
 }

--- a/workflowhelpers/internal/user.go
+++ b/workflowhelpers/internal/user.go
@@ -17,6 +17,7 @@ import (
 type TestUser struct {
 	username       string
 	password       string
+	origin         string
 	cmdStarter     internal.Starter
 	timeout        time.Duration
 	shouldKeepUser bool
@@ -26,6 +27,7 @@ type UserConfig interface {
 	GetUseExistingUser() bool
 	GetExistingUser() string
 	GetExistingUserPassword() string
+	GetExistingUserOrigin() string
 	GetShouldKeepUser() bool
 	GetConfigurableTestPassword() string
 }
@@ -53,11 +55,13 @@ type AdminClientConfig interface {
 }
 
 func NewTestUser(config userConfig, cmdStarter internal.Starter) *TestUser {
-	var regUser, regUserPass string
+	var regUser, regUserPass, regUserOrigin string
 
 	if config.GetUseExistingUser() {
 		regUser = config.GetExistingUser()
 		regUserPass = config.GetExistingUserPassword()
+		regUserOrigin = config.GetExistingUserOrigin()
+
 	} else {
 		regUser = generator.PrefixedRandomName(config.GetNamePrefix(), "USER")
 		regUserPass = generatePassword()
@@ -70,6 +74,7 @@ func NewTestUser(config userConfig, cmdStarter internal.Starter) *TestUser {
 	return &TestUser{
 		username:       regUser,
 		password:       regUserPass,
+		origin:         regUserOrigin,
 		cmdStarter:     cmdStarter,
 		timeout:        config.GetScaledTimeout(1 * time.Minute),
 		shouldKeepUser: config.GetShouldKeepUser(),
@@ -123,6 +128,10 @@ func (user *TestUser) Username() string {
 
 func (user *TestUser) Password() string {
 	return user.password
+}
+
+func (user *TestUser) Origin() string {
+	return user.origin
 }
 
 func (user *TestUser) ShouldRemain() bool {

--- a/workflowhelpers/test_suite_setup_test.go
+++ b/workflowhelpers/test_suite_setup_test.go
@@ -259,6 +259,8 @@ var _ = Describe("ReproducibleTestSuiteSetup", func() {
 				Expect(regularUserContext.Password).To(Equal(cfg.ExistingClientSecret))
 				Expect(setup.SkipUserCreation).To(BeTrue())
 			})
+
+
 		})
 	})
 
@@ -293,8 +295,8 @@ var _ = Describe("ReproducibleTestSuiteSetup", func() {
 			regularUserCmdStarter = starterFakes.NewFakeCmdStarter()
 			adminUserCmdStarter = starterFakes.NewFakeCmdStarter()
 
-			fakeRegularUserValues = fakes.NewFakeUserValues("username", "password")
-			fakeAdminUserValues = fakes.NewFakeUserValues("admin", "admin")
+			fakeRegularUserValues = fakes.NewFakeUserValues("username", "password", "")
+			fakeAdminUserValues = fakes.NewFakeUserValues("admin", "admin", "")
 			fakeSpaceValues = fakes.NewFakeSpaceValues("org", "space")
 
 			regularUserContext = UserContext{
@@ -396,8 +398,8 @@ var _ = Describe("ReproducibleTestSuiteSetup", func() {
 			regularUserCmdStarter = starterFakes.NewFakeCmdStarter()
 			adminUserCmdStarter = starterFakes.NewFakeCmdStarter()
 
-			fakeRegularUserValues = fakes.NewFakeUserValues("username", "password")
-			fakeAdminUserValues = fakes.NewFakeUserValues("admin", "admin")
+			fakeRegularUserValues = fakes.NewFakeUserValues("username", "password", "")
+			fakeAdminUserValues = fakes.NewFakeUserValues("admin", "admin", "")
 			fakeSpaceValues = fakes.NewFakeSpaceValues("org", "space")
 
 			regularUserContext = UserContext{

--- a/workflowhelpers/user_context.go
+++ b/workflowhelpers/user_context.go
@@ -20,6 +20,7 @@ import (
 type userValues interface {
 	Username() string
 	Password() string
+	Origin()   string
 }
 
 type spaceValues interface {
@@ -41,6 +42,7 @@ type UserContext struct {
 	Password string
 	Org      string
 	Space    string
+	Origin   string
 
 	UseClientCredentials bool
 }
@@ -75,6 +77,7 @@ func NewUserContext(apiUrl string, testUser userValues, testSpace spaceValues, s
 		ApiUrl:            apiUrl,
 		Username:          testUser.Username(),
 		Password:          testUser.Password(),
+		Origin:            testUser.Origin(),
 		TestSpace:         testSpace,
 		TestUser:          testUser,
 		Org:               org,
@@ -101,7 +104,7 @@ func (uc UserContext) Login() {
 	if uc.UseClientCredentials {
 		err = workflowhelpersinternal.CfClientAuth(uc.CommandStarter, redactingReporter, uc.TestUser.Username(), uc.TestUser.Password(), uc.Timeout)
 	} else {
-		err = workflowhelpersinternal.CfAuth(uc.CommandStarter, redactingReporter, uc.TestUser.Username(), uc.TestUser.Password(), uc.Timeout)
+		err = workflowhelpersinternal.CfAuth(uc.CommandStarter, redactingReporter, uc.TestUser.Username(), uc.TestUser.Password(), uc.TestUser.Origin(), uc.Timeout)
 	}
 
 	Expect(err).NotTo(HaveOccurred())

--- a/workflowhelpers/user_context_test.go
+++ b/workflowhelpers/user_context_test.go
@@ -45,6 +45,10 @@ var _ = Describe("UserContext", func() {
 			Expect(createUser().Password).To(Equal(testUser.Password()))
 		})
 
+		It("sets UserContext.Origin", func() {
+			Expect(createUser().Origin).To(Equal(testUser.Origin()))
+		})
+
 		It("sets UserContext.Org", func() {
 			Expect(createUser().Org).To(Equal(testSpace.OrganizationName()))
 		})
@@ -121,6 +125,20 @@ var _ = Describe("UserContext", func() {
 
 				Expect(fakeStarter.CalledWith[1].Executable).To(Equal("cf"))
 				Expect(fakeStarter.CalledWith[1].Args).To(Equal([]string{"auth", testUser.Username(), testUser.Password(), "--client-credentials"}))
+			})
+		})
+
+		Context("when Origin is set", func() {
+			BeforeEach(func() {
+				testUser = internal.NewTestUser(&config.Config{ExistingUserOrigin: "origin", UseExistingUser: true}, &fakes.FakeCmdStarter{})
+			})
+			It("uses --origin auth method", func() {
+				userContext.Login()
+
+				Expect(fakeStarter.CalledWith).To(HaveLen(2))
+
+				Expect(fakeStarter.CalledWith[1].Executable).To(Equal("cf"))
+				Expect(fakeStarter.CalledWith[1].Args).To(Equal([]string{"auth", testUser.Username(), testUser.Password(), "--origin", testUser.Origin()}))
 			})
 		})
 


### PR DESCRIPTION
Internal tests are run using an existing user with the `--origin uaa` flag required to auth